### PR TITLE
Update Rebel Build Action's GitHub Actions

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout Rebel Build Action
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build Rebel
         uses: ./

--- a/action.yaml
+++ b/action.yaml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Checkout Rebel Engine
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: RebelToolbox/RebelEngine
         path: RebelEngine
@@ -25,7 +25,7 @@ runs:
       run: echo "SCONS_CACHE=.scons-cache/" >> $GITHUB_ENV
 
     - name: Setup SCons cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: RebelEngine/${{ env.SCONS_CACHE }}
         key: ${{ github.job }}-${{ strategy.job-index }}-${{ github.sha }}
@@ -67,7 +67,7 @@ runs:
         echo "::endgroup::"
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact }}
         path: RebelEngine/bin/${{ inputs.rebel-executable }}


### PR DESCRIPTION
When using Rebel Build Action the following warning is being raised:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
The end-of-life date for Node.js 16 was brought forward by seven months to coincide with the end of support of OpenSSL 1.1.1 on 11th September 2023.[[1](https://nodejs.org/en/blog/announcements/nodejs16-eol/)]. This prompted GitHub to initiate the deprecation process for GitHub Actions using Node.js 16 and transition all actions to run on Node 20 by Spring 2024.[[2](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)].

This PR upgrades the GitHub Actions that Rebel Build Action uses to the latest versions:
- [actions/cache](https://github.com/actions/cache): v4
- [actions/checkout](https://github.com/actions/checkout): v4
- [actions/upload-artifact](https://github.com/actions/upload-artifact): v4

It includes updating the Build Tests' workflow to use GitHub's checkout action to v4 too.

[1] https://nodejs.org/en/blog/announcements/nodejs16-eol/
[2] https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/