### PR TITLE
On macOS, use Python to install SCons

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -71,9 +71,10 @@ runs:
         fi
         if [[ "${{ runner.os }}" == "macOS" ]]; then
           echo "::group::Installing macOS dependencies"
+          python -m ensurepip --upgrade
+          python -m pip install scons
           brew update
           brew install \
-          scons        \
           yasm
           echo "::endgroup::"
         fi


### PR DESCRIPTION
A recent update to the macOS Homebrew SCons package results in it attempting to update the Python version, which fails with:
```
2024-03-08T07:53:02.0291370Z [31mError:[0m The `brew link` step did not complete successfully
2024-03-08T07:53:02.0292300Z The formula built, but is not symlinked into /usr/local
2024-03-08T07:53:02.0293430Z Could not symlink bin/2to3
2024-03-08T07:53:02.0294250Z Target /usr/local/bin/2to3
2024-03-08T07:53:02.0295190Z already exists. You may want to remove it:
2024-03-08T07:53:02.0296320Z   rm '/usr/local/bin/2to3'
2024-03-08T07:53:02.0296980Z 
2024-03-08T07:53:02.0297290Z To force the link and overwrite all conflicting files:
2024-03-08T07:53:02.0298370Z   brew link --overwrite python@3.12
2024-03-08T07:53:02.0298780Z 
2024-03-08T07:53:02.0298980Z To list all files that would be deleted:
2024-03-08T07:53:02.0299710Z   brew link --overwrite python@3.12 --dry-run
2024-03-08T07:53:02.0300140Z 
2024-03-08T07:53:02.0300560Z Possible conflicting files are:
2024-03-08T07:53:02.0301570Z /usr/local/bin/2to3 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/2to3
2024-03-08T07:53:02.0302910Z /usr/local/bin/2to3-3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/2to3-3.12
2024-03-08T07:53:02.0304590Z /usr/local/bin/idle3 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/idle3
2024-03-08T07:53:02.0306080Z /usr/local/bin/idle3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/idle3.12
2024-03-08T07:53:02.0309720Z /usr/local/bin/pydoc3 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/pydoc3
2024-03-08T07:53:02.0312330Z /usr/local/bin/pydoc3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/pydoc3.12
2024-03-08T07:53:02.0314710Z /usr/local/bin/python3 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3
2024-03-08T07:53:02.0317060Z /usr/local/bin/python3-config -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3-config
2024-03-08T07:53:02.0320400Z /usr/local/bin/python3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12
2024-03-08T07:53:02.0323650Z /usr/local/bin/python3.12-config -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12-config
2024-03-08T07:53:02.0328640Z /usr/local/share/man/man1/python3.1 -> /usr/local/Cellar/python@3.11/3.11.7_1/share/man/man1/python3.1
2024-03-08T07:53:02.0339210Z /usr/local/lib/pkgconfig/python3-embed.pc -> /usr/local/Cellar/python@3.11/3.11.7_1/lib/pkgconfig/python3-embed.pc
2024-03-08T07:53:02.0341840Z /usr/local/lib/pkgconfig/python3.pc -> /usr/local/Cellar/python@3.11/3.11.7_1/lib/pkgconfig/python3.pc
2024-03-08T07:53:02.0346960Z /usr/local/Frameworks/Python.framework/Headers -> /usr/local/Cellar/python@3.11/3.11.7_1/Frameworks/Python.framework/Headers
2024-03-08T07:53:02.0349620Z /usr/local/Frameworks/Python.framework/Python -> /usr/local/Cellar/python@3.11/3.11.7_1/Frameworks/Python.framework/Python
2024-03-08T07:53:02.0352210Z /usr/local/Frameworks/Python.framework/Resources -> /usr/local/Cellar/python@3.11/3.11.7_1/Frameworks/Python.framework/Resources
2024-03-08T07:53:02.0357660Z /usr/local/Frameworks/Python.framework/Versions/Current -> /usr/local/Cellar/python@3.11/3.11.7_1/Frameworks/Python.framework/Versions/Current
2024-03-08T07:53:04.1486710Z [34m==>[0m [1m/usr/local/Cellar/python@3.12/3.12.2_1/bin/python3.12 -Im ensurepip[0m
2024-03-08T07:53:08.7532480Z [34m==>[0m [1m/usr/local/Cellar/python@3.12/3.12.2_1/bin/python3.12 -Im pip install -v --n[0m
2024-03-08T07:53:11.2620240Z [34m==>[0m [1mSummary[0m
2024-03-08T07:53:11.3397380Z 🍺  /usr/local/Cellar/python@3.12/3.12.2_1: 3,237 files, 63.8MB
2024-03-08T07:53:11.3401680Z [32m==>[0m [1mInstalling [32mscons[39m[0m
2024-03-08T07:53:11.3406960Z [34m==>[0m [1mPouring scons--4.6.0.monterey.bottle.2.tar.gz[0m
2024-03-08T07:53:12.8316250Z 🍺  /usr/local/Cellar/scons/4.6.0: 1,558 files, 19.4MB
```
Updating Python on macOS is a common problem; so we want to avoid it.

This PR reverses the dependency install logic. Since Python is already installed, we install SCons using Python; instead of installing SCons that then tries to install Python.