### PR TITLE
Remove support for 32-bit Linux builds

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -19,12 +19,6 @@ jobs:
             build-options: production=yes target=release_debug
             rebel-executable: rebel.linux.opt.tools.64
 
-          - name: Build Linux Rebel Engine 32 bit
-            os: ubuntu-latest
-            artifact: linux-engine-x86-32
-            build-options: production=yes tools=no target=release bits=32
-            rebel-executable: rebel.x11.opt.32
-
           - name: Build Windows Rebel Editor on Linux
             os: ubuntu-latest
             artifact: windows-editor-mingw-linux

--- a/action.yaml
+++ b/action.yaml
@@ -30,11 +30,9 @@ runs:
         #Install dependencies
         if [[ "${{ runner.os }}" == "Linux" ]]; then
           echo "::group::Installing Linux dependencies"
-          sudo dpkg --add-architecture i386
           sudo apt-get update
           sudo apt-get install -y \
           build-essential         \
-          g++-multilib            \
           pkg-config              \
           clang                   \
           lld                     \
@@ -50,15 +48,6 @@ runs:
           libudev-dev             \
           libasound2-dev          \
           libpulse-dev            \
-          libx11-dev:i386         \
-          libxcursor-dev:i386     \
-          libxinerama-dev:i386    \
-          libxrandr-dev:i386      \
-          libxi-dev:i386          \
-          libgl-dev:i386          \
-          libudev-dev:i386        \
-          libasound2-dev:i386     \
-          libpulse-dev:i386       \
           yasm
           sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
           echo "::endgroup::"


### PR DESCRIPTION
32 bit hardware is no longer being produced. Ubuntu 18.04 LTS was the last version that supported 32-bits. Ubuntu 18.04 was a long-term support version that was supported for five years, but that support ended in May 2023. Although our builds still worked on Ubuntu 22.04 LTS, they no longer work on Ubuntu 24.04 LTS, which was released earlier this year. There are other Linux distributions that still provide [32-bit versions](https://itsfoss.com/32-bit-linux-distributions/). However, Ubuntu is used to create the Linux Rebel Engine builds. We could continue to build Linux 32-bit Rebel Engine builds on Ubuntu 22.04 LTS until it reaches end of live in April 2027. However, it makes sense to accept that 32-bit support has ended. 

This PR removes support for Linux 32-bit builds from the build action.