### PR TITLE
Don't cancel build tests running on the main branch

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
   build-tests:


### PR DESCRIPTION
Currently, if a branch or a pull request is updated, to save time and resources, in progress build tests are cancelled and a new build test is started. However, for updates to the main branch, we want all build tests to run to completion. Specifically, when merging multiple pull requests, we want to test all merges. We do not want a new merge to cancel tests running on a previous merge.

Since the only way to update the main branch is through merging a pull request, this PR ensures that all updates to the main do not cancel in progress build tests.
