### PR TITLE
Create release configuration file

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - github-actions
+  categories:
+    - title: Breaking Changes ⚠️
+      labels:
+        - "PR Type: Breaking Change"
+    - title: Exciting New Features ✨
+      labels:
+        - "PR Type: New Feature"
+    - title: Bug Fixes 🐛
+      labels:
+        - "PR Type: Bug Fix"
+    - title: Enhancements 🚀
+      labels:
+        - "PR Type: Enhancement"
+    - title: Maintenance Updates 🔧
+      labels:
+        - "PR Type: Maintenance"
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Creates a release configuration file that is used to automatically generate release notes. Instead of just providing a link to the list of commits since the last version, it will:
- Include a list of all the PRs since the last version.
- Group PRs by category for each of the PR Type: * [labels](https://github.com/RebelToolbox/RebelBuildAction/labels).
- Remove @dependabot and @github-actions bots from the list of new contributors.
