### PR TITLE
Remove Linux' emscripten dependency

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -44,7 +44,6 @@ runs:
           clang                   \
           lld                     \
           mingw-w64               \
-          emscripten              \
           scons                   \
           libx11-dev              \
           libxcursor-dev          \


### PR DESCRIPTION
RebelToolbox/RebelEngine#257 updated web builds to install the latest version of Emscripten automatically, which removed the need to install Emscripten manually.

This PR removes the Emscripten Linux dependency.