### PR TITLE
Use older versions of Windows and macOS for build tests

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -24,7 +24,7 @@ jobs:
             build-options: platform=windows production=yes target=release_debug
 
           - name: Build Windows Rebel Editor using MSVC
-            os: windows-latest
+            os: windows-2022
             artifact: windows-editor-msvc
             build-options: production=yes target=release_debug
 
@@ -34,7 +34,7 @@ jobs:
             build-options: production=yes target=release_debug use_mingw=yes
 
           - name: Build macOS Rebel Editor
-            os: macOS-latest
+            os: macos-15
             artifact: macos-editor
             build-options: production=yes target=release_debug
 


### PR DESCRIPTION
As discussed in RebelToolbox/RebelEngine#344, currently our test builds fail when using the new Windows Server 2025 with Visual Studio 2026 [[1](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-VS2026-Readme.md)] and macOS 26 [[2](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md)] "latest" runners. Therefore, we need to set the runners used to an older version until the breaking changes can be addressed.

This PR fixes the Windows OS used to test our Windows MSVC build to Windows 2022 (with Visual Studio 2022) and the macOS used to test our macOS build to macOS 15.

References:
[1] https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-VS2026-Readme.md
[2] https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md